### PR TITLE
add flag for ignoring errors related to sysctl configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ All variables are also listed in default values.
 | cni_plugin_dir | yes | /opt/cni/bin | directory where downloaded file and plugins are stored
 | cni_plugin_release_url | yes | https://github.com/containernetworking/plugins/releases/download | Release url for cni plugins
 | cni_plugin_release_version | yes | v1.0.1 | Version of cni-plugins
+| cni_plugin_custom_sysctl_conf | no | false | Whether the modification of sysctl.conf is allowed to fail 
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ All variables are also listed in default values.
 | cni_plugin_dir | yes | /opt/cni/bin | directory where downloaded file and plugins are stored
 | cni_plugin_release_url | yes | https://github.com/containernetworking/plugins/releases/download | Release url for cni plugins
 | cni_plugin_release_version | yes | v1.0.1 | Version of cni-plugins
-| cni_plugin_custom_sysctl_conf | no | false | Whether the modification of sysctl.conf is allowed to fail 
+| cni_plugin_sysctl_ignore_unknown_keys | no | false | Whether unknown keys in sysctl.conf are allowed
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,4 +2,4 @@
 cni_plugin_dir: /opt/cni/bin
 cni_plugin_release_version: v1.0.1
 cni_plugin_release_url: https://github.com/containernetworking/plugins/releases/download
-cni_plugin_custom_sysctl_conf: false
+cni_plugin_sysctl_ignore_unknown_keys: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 cni_plugin_dir: /opt/cni/bin
 cni_plugin_release_version: v1.0.1
 cni_plugin_release_url: https://github.com/containernetworking/plugins/releases/download
+cni_plugin_custom_sysctl_conf: false

--- a/tasks/linux/main.yml
+++ b/tasks/linux/main.yml
@@ -19,9 +19,9 @@
     state: present
     value: 1
     reload: true
+    ignoreerrors: "{{ cni_plugin_custom_sysctl_conf | bool }}"
   with_items:
     - net.bridge.bridge-nf-call-iptables
     - net.bridge.bridge-nf-call-arptables
     - net.bridge.bridge-nf-call-ip6tables
-  ignore_errors: "{{ cni_plugin_custom_sysctl_conf | bool }}"
   when: ansible_virtualization_type not in ['docker', 'lxc', 'openvz']

--- a/tasks/linux/main.yml
+++ b/tasks/linux/main.yml
@@ -23,4 +23,5 @@
     - net.bridge.bridge-nf-call-iptables
     - net.bridge.bridge-nf-call-arptables
     - net.bridge.bridge-nf-call-ip6tables
+  ignore_errors: "{{ cni_plugin_custom_sysctl_conf | bool }}"
   when: ansible_virtualization_type not in ['docker', 'lxc', 'openvz']

--- a/tasks/linux/main.yml
+++ b/tasks/linux/main.yml
@@ -19,7 +19,7 @@
     state: present
     value: 1
     reload: true
-    ignoreerrors: "{{ cni_plugin_custom_sysctl_conf | bool }}"
+    ignoreerrors: "{{ cni_plugin_sysctl_ignore_unknown_keys | bool }}"
   with_items:
     - net.bridge.bridge-nf-call-iptables
     - net.bridge.bridge-nf-call-arptables


### PR DESCRIPTION
@xFuture603 Here is the PR related to our short discussion. Another option would be to load the required kernel modules before.